### PR TITLE
Don't err with the "string out of bounds" exception while throwing "Unsupported command" exception

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/Parser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/Parser.java
@@ -390,7 +390,9 @@ public final class Parser {
         throw new ParserException(MessageFormat.format(
                 Resources.getString("CannotParseStringUnsupportedCommand"),
                 string, position + 1,
-                string.substring(position, position + 20)));
+                string.substring(
+                    position,
+                    (string.length() > position + 20 ? position + 20 : string.length()))));
     }
 
     /**


### PR DESCRIPTION
Out of the box agpdiff failed on my SQL dump with:

```
Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: 85
    at java.lang.String.substring(String.java:1934)
    at cz.startnet.utils.pgdiff.parsers.Parser.throwUnsupportedCommand(Parser.java:390)
    at cz.startnet.utils.pgdiff.parsers.AlterTableParser.parseAlterColumn(AlterTableParser.java:291)
    at cz.startnet.utils.pgdiff.parsers.AlterTableParser.parse(AlterTableParser.java:79)
    at cz.startnet.utils.pgdiff.loader.PgDumpLoader.loadDatabaseSchema(PgDumpLoader.java:180)
    at cz.startnet.utils.pgdiff.loader.PgDumpLoader.loadDatabaseSchema(PgDumpLoader.java:236)
    at cz.startnet.utils.pgdiff.PgDiff.createDiff(PgDiff.java:29)
    at cz.startnet.utils.pgdiff.Main.main(Main.java:39)
```

With this patch it fails with a more sensible:

```
Exception in thread "main" cz.startnet.utils.pgdiff.parsers.ParserException: Cannot parse string: ALTER TABLE download_texts ALTER COLUMN download_text_length set NOT NULL;
Unsupported command at position 66 'NOT NULL;'
    at cz.startnet.utils.pgdiff.parsers.Parser.throwUnsupportedCommand(Parser.java:390)
    at cz.startnet.utils.pgdiff.parsers.AlterTableParser.parseAlterColumn(AlterTableParser.java:291)
    at cz.startnet.utils.pgdiff.parsers.AlterTableParser.parse(AlterTableParser.java:79)
    at cz.startnet.utils.pgdiff.loader.PgDumpLoader.loadDatabaseSchema(PgDumpLoader.java:180)
    at cz.startnet.utils.pgdiff.loader.PgDumpLoader.loadDatabaseSchema(PgDumpLoader.java:236)
    at cz.startnet.utils.pgdiff.PgDiff.createDiff(PgDiff.java:29)
    at cz.startnet.utils.pgdiff.Main.main(Main.java:39)
```
