### PR TITLE
strip comment like '/* i am comment */' 

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
@@ -329,6 +329,12 @@ public class PgDumpLoader { //NOPMD
 
             pos = sbStatement.indexOf("--", pos + 1);
         }
+        
+        int endPos = sbStatement.indexOf("*/");
+        if(endPos>=0){
+        	int startPos = sbStatement.indexOf("/*");
+        	sbStatement.replace(startPos, endPos+2, "");
+        }
     }
 
     /**


### PR DESCRIPTION
sometimes the sql file is not dumped by pgsql , it may be exported by some database design tools (eg:er master or power designer) .
so it may contains some comment like  '/* i am comment */'.
if the sql is like this:
/ * create table begin */
create table table_name(
    ...
);

the table will be 	ignored by pgdiff,so i add a check for this scene