### PR TITLE
Fixes for Issue: 116

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/Pair.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/Pair.java
@@ -1,0 +1,14 @@
+package cz.startnet.utils.pgdiff;
+
+public class Pair<L,R> {
+    private L l;
+    private R r;
+    public Pair(L l, R r){
+        this.l = l;
+        this.r = r;
+    }
+    public L getL(){ return l; }
+    public R getR(){ return r; }
+    public void setL(L l){ this.l = l; }
+    public void setR(R r){ this.r = r; }
+}

--- a/src/main/java/cz/startnet/utils/pgdiff/PgDiffTables.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/PgDiffTables.java
@@ -5,7 +5,7 @@
  */
 package cz.startnet.utils.pgdiff;
 
-import cz.startnet.utils.pgdiff.parsers.Pair;
+import cz.startnet.utils.pgdiff.Pair;
 import cz.startnet.utils.pgdiff.schema.PgColumn;
 import cz.startnet.utils.pgdiff.schema.PgColumnUtils;
 import cz.startnet.utils.pgdiff.schema.PgSchema;

--- a/src/main/java/cz/startnet/utils/pgdiff/PgDiffTables.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/PgDiffTables.java
@@ -5,6 +5,7 @@
  */
 package cz.startnet.utils.pgdiff;
 
+import cz.startnet.utils.pgdiff.parsers.Pair;
 import cz.startnet.utils.pgdiff.schema.PgColumn;
 import cz.startnet.utils.pgdiff.schema.PgColumnUtils;
 import cz.startnet.utils.pgdiff.schema.PgSchema;
@@ -130,7 +131,7 @@ public class PgDiffTables {
             updateTableColumns(
                     writer, arguments, oldTable, newTable, searchPathHelper);
             checkWithOIDS(writer, oldTable, newTable, searchPathHelper);
-            checkInherits(writer, oldTable, newTable, searchPathHelper);
+            checkInherits(writer, oldTable, newTable, newSchema, searchPathHelper);
             checkTablespace(writer, oldTable, newTable, searchPathHelper);
             addAlterStatistics(writer, oldTable, newTable, searchPathHelper);
             addAlterStorage(writer, oldTable, newTable, searchPathHelper);
@@ -354,30 +355,62 @@ public class PgDiffTables {
      * @param writer           writer the output should be written to
      * @param oldTable         original table
      * @param newTable         new table
+     * @param newSchema        new schema
      * @param searchPathHelper search path helper
      */
     private static void checkInherits(final PrintWriter writer,
             final PgTable oldTable, final PgTable newTable,
+            final PgSchema newSchema,
             final SearchPathHelper searchPathHelper) {
-        for (final String tableName : oldTable.getInherits()) {
-            if (!newTable.getInherits().contains(tableName)) {
+        for (final Pair<String,String> inheritPairO : oldTable.getInherits()) {
+            final String schemaName = inheritPairO.getL();
+            final String tableName = inheritPairO.getR();
+            boolean isFound = false;
+            for (final Pair<String,String> inheritPairN : newTable.getInherits()) {
+              if(schemaName.equals(inheritPairN.getL()) && tableName.equals(inheritPairN.getR())) {
+                  isFound = true;
+                  break;
+              }
+            }
+            if (!isFound) {
+                String inheritTableName = null;
+                if(newSchema.getName().equals(schemaName)){
+                    inheritTableName = PgDiffUtils.getQuotedName(tableName);
+                } else {
+                    inheritTableName = String.format("%s.%s",PgDiffUtils.getQuotedName(schemaName),PgDiffUtils.getQuotedName(tableName));
+                }
                 searchPathHelper.outputSearchPath(writer);
                 writer.println();
                 writer.println("ALTER TABLE "
                         + PgDiffUtils.getQuotedName(newTable.getName()));
                 writer.println("\tNO INHERIT "
-                        + PgDiffUtils.getQuotedName(tableName) + ';');
+                        + inheritTableName + ';');
             }
         }
 
-        for (final String tableName : newTable.getInherits()) {
-            if (!oldTable.getInherits().contains(tableName)) {
+        for (final Pair<String,String> inheritPairN : newTable.getInherits()) {
+            final String schemaName = inheritPairN.getL();
+            final String tableName = inheritPairN.getR();
+            boolean isFound = false;
+            for (final Pair<String,String> inheritPairO : oldTable.getInherits()) {
+              if(schemaName.equals(inheritPairO.getL()) && tableName.equals(inheritPairO.getR())) {
+                  isFound = true;
+                  break;
+              }
+            }
+            if (!isFound) {
+                String inheritTableName = null;
+                if(newSchema.getName().equals(schemaName)){
+                    inheritTableName = PgDiffUtils.getQuotedName(tableName);
+                } else {
+                    inheritTableName = String.format("%s.%s",PgDiffUtils.getQuotedName(schemaName),PgDiffUtils.getQuotedName(tableName));
+                }
                 searchPathHelper.outputSearchPath(writer);
                 writer.println();
                 writer.println("ALTER TABLE "
                         + PgDiffUtils.getQuotedName(newTable.getName()));
                 writer.println("\tINHERIT "
-                        + PgDiffUtils.getQuotedName(tableName) + ';');
+                        + inheritTableName + ';');
             }
         }
     }

--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/AlterTableParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/AlterTableParser.java
@@ -9,6 +9,7 @@ import cz.startnet.utils.pgdiff.Resources;
 import cz.startnet.utils.pgdiff.schema.PgColumn;
 import cz.startnet.utils.pgdiff.schema.PgConstraint;
 import cz.startnet.utils.pgdiff.schema.PgDatabase;
+import cz.startnet.utils.pgdiff.schema.PgInheritedColumn;
 import cz.startnet.utils.pgdiff.schema.PgSchema;
 import cz.startnet.utils.pgdiff.schema.PgSequence;
 import cz.startnet.utils.pgdiff.schema.PgTable;
@@ -261,6 +262,17 @@ public class AlterTableParser {
                                 parser.getString()));
                     }
 
+                    column.setDefaultValue(defaultValue);
+                } else if (table.containsInheritedColumn(columnName)) {
+                    final PgInheritedColumn column = table.getInheritedColumn(columnName);
+                    
+                    if (column == null) {
+                        throw new RuntimeException(MessageFormat.format(
+                                Resources.getString("CannotFindTableColumn"),
+                                columnName, table.getName(),
+                                parser.getString()));
+                    }
+                    
                     column.setDefaultValue(defaultValue);
                 } else {
                     throw new ParserException(MessageFormat.format(

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgInheritedColumn.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgInheritedColumn.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2006 StartNet s.r.o.
+ *
+ * Distributed under MIT license
+ */
+package cz.startnet.utils.pgdiff.schema;
+
+/**
+ * Stores inherited column information.
+ *
+ * @author dwatson78
+ */
+ public class PgInheritedColumn {
+    /**
+     * Inherited column
+     */
+    private final PgColumn inheritedColumn;
+    
+    public PgInheritedColumn(final PgColumn inheritedColumn) {
+        this.inheritedColumn = inheritedColumn;
+    }
+    
+    /**
+     * Getter for {@link #inheritedColumn}.
+     *
+     * @return {@link #inheritedColumn}
+     */
+    public PgColumn getInheritedColumn() {
+        return inheritedColumn;
+    }
+    
+    /**
+     * Default value of the column.
+     */
+    private String defaultValue;
+    
+    /**
+     * Setter for {@link #defaultValue}.
+     *
+     * @param defaultValue {@link #defaultValue}
+     */
+    public void setDefaultValue(final String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+    
+    /**
+     * Getter for {@link #defaultValue}.
+     *
+     * @return {@link #defaultValue}
+     */
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+ }

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgTable.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgTable.java
@@ -303,7 +303,7 @@ public class PgTable {
         for (PgColumn column : getColumnsWithStatistics()) {
             sbSQL.append("\nALTER TABLE ONLY ");
             sbSQL.append(PgDiffUtils.getQuotedName(name));
-            sbSQL.append("ALTER COLUMN ");
+            sbSQL.append(" ALTER COLUMN ");
             sbSQL.append(
                     PgDiffUtils.getQuotedName(column.getName()));
             sbSQL.append(" SET STATISTICS ");

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgTable.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgTable.java
@@ -5,7 +5,7 @@
  */
 package cz.startnet.utils.pgdiff.schema;
 
-import cz.startnet.utils.pgdiff.parsers.Pair;
+import cz.startnet.utils.pgdiff.Pair;
 import cz.startnet.utils.pgdiff.PgDiffUtils;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgTable.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgTable.java
@@ -24,6 +24,11 @@ public class PgTable {
     @SuppressWarnings("CollectionWithoutInitialCapacity")
     private final List<PgColumn> columns = new ArrayList<PgColumn>();
     /**
+     * List of inheritedColumns defined on the table.
+     */
+    @SuppressWarnings("CollectionWithoutInitialCapacity")
+    private final List<PgInheritedColumn> inheritedColumns = new ArrayList<PgInheritedColumn>();
+    /**
      * List of constraints defined on the table.
      */
     @SuppressWarnings("CollectionWithoutInitialCapacity")
@@ -118,12 +123,22 @@ public class PgTable {
                 return column;
             }
         }
+        return null;
+    }
+    
+    /**
+     * Finds inheritedColumn according to specified name {@code name}.
+     *
+     * @param name name of the inheritedColumn to be searched
+     *
+     * @return found inheritedColumn or null if no such inheritedColumn
+     * has been found
+     */
+    public PgInheritedColumn getInheritedColumn(final String name) {
         if (inherits != null && !inherits.isEmpty()) {
-            for (final Pair<String, String> inheritPair : inherits) {
-                if (database.getSchema(inheritPair.getL()).containsTable(inheritPair.getR())) {
-                  if(database.getSchema(inheritPair.getL()).getTable(inheritPair.getR()).containsColumn(name)) {
-                    return database.getSchema(inheritPair.getL()).getTable(inheritPair.getR()).getColumn(name); 
-                  }
+            for (PgInheritedColumn inheritedColumn : inheritedColumns) {
+                if (inheritedColumn.getInheritedColumn().getName().equals(name)) {
+                    return inheritedColumn;
                 }
             }
         }
@@ -137,6 +152,15 @@ public class PgTable {
      */
     public List<PgColumn> getColumns() {
         return Collections.unmodifiableList(columns);
+    }
+    
+    /**
+     * Getter for {@link #inheritedColumns}. The list cannot be modified.
+     *
+     * @return {@link #inheritedColumns}
+     */
+    public List<PgInheritedColumn> getInheritedColumns() {
+        return Collections.unmodifiableList(inheritedColumns);
     }
 
     /**
@@ -185,10 +209,12 @@ public class PgTable {
 
     /**
      * Creates and returns SQL for creation of the table.
+     * 
+     * @param schema schema of current statement
      *
      * @return created SQL statement
      */
-    public String getCreationSQL() {
+    public String getCreationSQL(final PgSchema schema) {
         final StringBuilder sbSQL = new StringBuilder(1000);
         sbSQL.append("CREATE TABLE ");
         sbSQL.append(PgDiffUtils.getQuotedName(name));
@@ -224,7 +250,13 @@ public class PgTable {
                 } else {
                     sbSQL.append(", ");
                 }
-                sbSQL.append(String.format("%s.%s", inheritPair.getL(), inheritPair.getR()));
+                String inheritTableName = null;
+                if(schema.getName().equals(inheritPair.getL())){
+                    inheritTableName = inheritPair.getR();
+                } else {
+                    inheritTableName = String.format("%s.%s", inheritPair.getL(), inheritPair.getR());
+                }
+                sbSQL.append(inheritTableName);
             }
 
             sbSQL.append(")");
@@ -253,11 +285,25 @@ public class PgTable {
         }
 
         sbSQL.append(';');
+        
+        //Inherited column default override
+        for (PgInheritedColumn column : getInheritedColumns()) {
+            if(column.getDefaultValue() != null){
+                sbSQL.append("\n\nALTER TABLE ONLY ");
+                sbSQL.append(PgDiffUtils.getQuotedName(name));
+                sbSQL.append("\n\tALTER COLUMN ");
+                sbSQL.append(
+                    PgDiffUtils.getQuotedName(column.getInheritedColumn().getName()));
+                sbSQL.append(" SET DEFAULT ");
+                sbSQL.append(column.getDefaultValue());
+                sbSQL.append(';');
+            }
+        }
 
         for (PgColumn column : getColumnsWithStatistics()) {
             sbSQL.append("\nALTER TABLE ONLY ");
             sbSQL.append(PgDiffUtils.getQuotedName(name));
-            sbSQL.append(" ALTER COLUMN ");
+            sbSQL.append("ALTER COLUMN ");
             sbSQL.append(
                     PgDiffUtils.getQuotedName(column.getName()));
             sbSQL.append(" SET STATISTICS ");
@@ -347,6 +393,11 @@ public class PgTable {
      */
     public void addInherits(final String schemaName, final String tableName) {
         inherits.add(new Pair<String, String>(schemaName, tableName));
+        final PgTable inheritedTable = database.getSchema(schemaName).getTable(tableName);
+        for( PgColumn column : inheritedTable.getColumns() ) {
+          PgInheritedColumn inheritedColumn = new PgInheritedColumn(column);
+          inheritedColumns.add(inheritedColumn);
+        }
     }
 
     /**
@@ -429,6 +480,15 @@ public class PgTable {
     public void addColumn(final PgColumn column) {
         columns.add(column);
     }
+    
+    /**
+     * Adds {@code inheritedColumn} to the list of inheritedColumns.
+     *
+     * @param inheritedColumn inheritedColumn
+     */
+    public void addInheritedColumn(final PgInheritedColumn inheritedColumn) {
+        inheritedColumns.add(inheritedColumn);
+    }
 
     /**
      * Adds {@code constraint} to the list of constraints.
@@ -471,14 +531,26 @@ public class PgTable {
                 return true;
             }
         }
-        if (inherits != null && !inherits.isEmpty()) {
-            for (final Pair<String,String> inheritPair : inherits) {
-                if (database.getSchema(inheritPair.getL()).containsTable(inheritPair.getR())) {
-                  return database.getSchema(inheritPair.getL()).getTable(inheritPair.getR()).containsColumn(name);
+        return false;
+    }
+    
+    /**
+     * Returns true if table contains given inheritedColumn {@code name},
+     * otherwise false.
+     *
+     * @param name name of the inheritedColumn
+     *
+     * @return true if table contains given inheritedColumn {@code name},
+     * otherwise false
+     */
+    public boolean containsInheritedColumn(final String name) {
+       if (inherits != null && !inherits.isEmpty()) {
+            for (PgInheritedColumn inheritedColumn : inheritedColumns) {
+                if (inheritedColumn.getInheritedColumn().getName().equals(name)) {
+                    return true;
                 }
             }
         }
-        
         return false;
     }
 

--- a/src/test/java/cz/startnet/utils/pgdiff/PgDiffTest.java
+++ b/src/test/java/cz/startnet/utils/pgdiff/PgDiffTest.java
@@ -97,6 +97,12 @@ public class PgDiffTest {
                     // Tests scenario where original and new TABLE contain
                     //different INHERITS.
                     {"modify_inherits", false, false, false, false},
+                    // Add a table with a default value for a column that belongs to an inherited table
+                    {"add_inherits_default_column", false, false, false, false},
+                    // Add a table with a default value for a column that belongs to an inherited table in a different schema
+                    {"add_inherits_schema_default_column", false, false, false, false},
+                    // Tests when a default value is changed for a column that belongs to an inherited table
+                    {"modify_default_value_inherited_column", false, false, false, false},
                     // Tests scenario where SEQUENCE is added.
                     {"add_sequence", false, false, false, false},
                     // Tests scenario where SEQUENCE is dropped.

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_default_column_diff.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_default_column_diff.sql
@@ -1,0 +1,7 @@
+
+CREATE TABLE childtable (
+)
+INHERITS (parenttable);
+
+ALTER TABLE ONLY childtable
+	ALTER COLUMN parenttable_id SET DEFAULT 0;

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_default_column_new.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_default_column_new.sql
@@ -1,0 +1,37 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = off;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET escape_string_warning = off;
+
+--
+-- Name: parenttable; Type: TABLE; Schema: public; Owner: admin; Tablespace: 
+--
+
+CREATE TABLE parenttable (
+    parenttable_id integer NOT NULL,
+    parenttable_date timestamptz NOT NULL
+);
+
+--
+-- Name: childtable; Type: TABLE; Schema: public; Owner: admin; Tablespace: 
+--
+
+CREATE TABLE childtable (
+)
+INHERITS (parenttable);
+
+--
+-- Name: childtable; Type: DEFAULT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY childtable ALTER COLUMN parenttable_id SET DEFAULT 0;
+
+--
+-- PostgreSQL database dump complete
+--

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_default_column_original.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_default_column_original.sql
@@ -1,0 +1,23 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = off;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET escape_string_warning = off;
+
+--
+-- Name: parenttable; Type: TABLE; Schema: public; Owner: admin; Tablespace: 
+--
+
+CREATE TABLE parenttable (
+    parenttable_id integer NOT NULL,
+    parenttable_date timestamptz NOT NULL
+);
+
+--
+-- PostgreSQL database dump complete
+--

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_diff.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_diff.sql
@@ -2,4 +2,4 @@
 CREATE TABLE testtable (
 	field1 polygon
 )
-INHERITS (parenttable);
+INHERITS (public.parenttable);

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_diff.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_diff.sql
@@ -2,4 +2,4 @@
 CREATE TABLE testtable (
 	field1 polygon
 )
-INHERITS (public.parenttable);
+INHERITS (parenttable);

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_schema_default_column_diff.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_schema_default_column_diff.sql
@@ -1,0 +1,12 @@
+
+CREATE SCHEMA schema1;
+
+SET search_path = schema1, pg_catalog;
+
+CREATE TABLE childtable (
+	childtable_date timestamptz NOT NULL
+)
+INHERITS (public.parenttable);
+
+ALTER TABLE ONLY childtable
+	ALTER COLUMN parenttable_id SET DEFAULT 0;

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_schema_default_column_new.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_schema_default_column_new.sql
@@ -40,7 +40,7 @@ INHERITS (public.parenttable);
 -- Name: parenttable_id; Type: DEFAULT; Schema: schema1; Owner: admin
 --
 
-ALTER TABLE ONLY schema1.childtable ALTER COLUMN parenttable_id SET DEFAULT 0;
+ALTER TABLE ONLY childtable ALTER COLUMN parenttable_id SET DEFAULT 0;
 
 --
 -- PostgreSQL database dump complete

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_schema_default_column_new.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_schema_default_column_new.sql
@@ -1,0 +1,47 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = off;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET escape_string_warning = off;
+
+--
+-- Name: schema1; Type: SCHEMA; Schema: -; Owner: admin
+--
+
+CREATE SCHEMA schema1;
+
+--
+-- Name: parenttable; Type: TABLE; Schema: public; Owner: admin; Tablespace: 
+--
+
+CREATE TABLE parenttable (
+    parenttable_id integer NOT NULL,
+    parenttable_date timestamptz NOT NULL
+);
+
+
+SET search_path = schema1, pg_catalog;
+
+--
+-- Name: childtable; Type: TABLE; Schema: schema1; Owner: admin; Tablespace: 
+--
+
+CREATE TABLE childtable (
+    childtable_date timestamptz NOT NULL
+)
+INHERITS (public.parenttable);
+
+--
+-- Name: parenttable_id; Type: DEFAULT; Schema: schema1; Owner: admin
+--
+
+ALTER TABLE ONLY schema1.childtable ALTER COLUMN parenttable_id SET DEFAULT 0;
+
+--
+-- PostgreSQL database dump complete
+--

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_schema_default_column_original.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_inherits_schema_default_column_original.sql
@@ -1,0 +1,23 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = off;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET escape_string_warning = off;
+
+--
+-- Name: parenttable; Type: TABLE; Schema: public; Owner: admin; Tablespace: 
+--
+
+CREATE TABLE parenttable (
+    parenttable_id integer NOT NULL,
+    parenttable_date timestamptz NOT NULL
+);
+
+--
+-- PostgreSQL database dump complete
+--

--- a/src/test/resources/cz/startnet/utils/pgdiff/modify_default_value_inherited_column_diff.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/modify_default_value_inherited_column_diff.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE ONLY childtable
+	ALTER COLUMN parenttable_id SET DEFAULT 1;

--- a/src/test/resources/cz/startnet/utils/pgdiff/modify_default_value_inherited_column_new.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/modify_default_value_inherited_column_new.sql
@@ -1,0 +1,37 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = off;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET escape_string_warning = off;
+
+--
+-- Name: parenttable; Type: TABLE; Schema: public; Owner: admin; Tablespace: 
+--
+
+CREATE TABLE parenttable (
+    parenttable_id integer NOT NULL,
+    parenttable_date timestamptz NOT NULL
+);
+
+--
+-- Name: childtable; Type: TABLE; Schema: public; Owner: admin; Tablespace: 
+--
+
+CREATE TABLE childtable (
+)
+INHERITS (parenttable);
+
+--
+-- Name: parenttable_id; Type: DEFAULT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY childtable ALTER COLUMN parenttable_id SET DEFAULT 1;
+
+--
+-- PostgreSQL database dump complete
+--

--- a/src/test/resources/cz/startnet/utils/pgdiff/modify_default_value_inherited_column_original.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/modify_default_value_inherited_column_original.sql
@@ -1,0 +1,37 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = off;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET escape_string_warning = off;
+
+--
+-- Name: parenttable; Type: TABLE; Schema: public; Owner: admin; Tablespace: 
+--
+
+CREATE TABLE parenttable (
+    parenttable_id integer NOT NULL,
+    parenttable_date timestamptz NOT NULL
+);
+
+--
+-- Name: childtable; Type: TABLE; Schema: public; Owner: admin; Tablespace: 
+--
+
+CREATE TABLE childtable (
+)
+INHERITS (parenttable);
+
+--
+-- Name: parenttable_id; Type: DEFAULT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY childtable ALTER COLUMN parenttable_id SET DEFAULT 0;
+
+--
+-- PostgreSQL database dump complete
+--


### PR DESCRIPTION
These fixes will allow apgdiff to preserve schema information on inherited tables and also allow a column to be identified by an inherited table if that column belongs to the table itself or one of it's inherited tables.