### PR TITLE
Add support for reading from stdin

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/PgDiff.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/PgDiff.java
@@ -27,6 +27,11 @@ public class PgDiff {
      */
     public static void createDiff(final PrintWriter writer,
             final PgDiffArguments arguments) {
+        // Avoid reading twice from System.in
+        if (arguments.getOldDumpFile().equals("-")
+                && arguments.getNewDumpFile().equals("-"))
+            return;
+
         final PgDatabase oldDatabase = PgDumpLoader.loadDatabaseSchema(
                 arguments.getOldDumpFile(), arguments.getInCharsetName(),
                 arguments.isOutputIgnoredStatements(),

--- a/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
@@ -281,6 +281,10 @@ public class PgDumpLoader { //NOPMD
     public static PgDatabase loadDatabaseSchema(final String file,
             final String charsetName, final boolean outputIgnoredStatements,
             final boolean ignoreSlonyTriggers) {
+        if (file.equals("-"))
+            return loadDatabaseSchema(System.in, charsetName,
+                    outputIgnoredStatements, ignoreSlonyTriggers);
+
         FileInputStream fis = null;
         try {
             fis = new FileInputStream(file);


### PR DESCRIPTION
This patch adds support for reading database dumps from stdin by specifying the filename "-", just like the diff command in UNIX.

Example usage: `zcat old.sql.gz | apgdiff - new.sql`
