### PR TITLE
Fixed the .pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <issueManagement>
         <system>GitHub Issue Tracker</system>
-        <url>https://github.com/fordfrog/apgdiff/issues?sort=created&state=open</url>
+        <url>https://github.com/fordfrog/apgdiff/issues?sort=created&amp;state=open</url>
     </issueManagement>
 
     <inceptionYear>2006</inceptionYear>


### PR DESCRIPTION
I escaped an ampersand in the issue management url; the un-escaped ampersand made building the project with maven 3.1.0 fail with
[ERROR]     Non-parseable POM
