### PR TITLE
Materialized view support (PostgreSQL 9.3+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ fordfrog@fordfrog.com.
 
 ### Version 2.4.1 (not released yet)
 
+#### New Features
+* MATERIALIZED VIEW support in PostgreSQL 9.3 (Marti Raudsepp)
+
 #### Fixes
 * Added hint to use "CREATE TABLE ... CONSTRAINT name PRIMARY KEY/UNIQUE ..."
   instead of "CREATE TABLE ... PRIMARY KEY/UNIQUE ..." because apgdiff cannot

--- a/src/main/java/cz/startnet/utils/pgdiff/PgDiffViews.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/PgDiffViews.java
@@ -81,6 +81,9 @@ public class PgDiffViews {
             final PgView newView) {
         final String[] oldViewColumnNames;
 
+        if (oldView.isMaterialized() != newView.isMaterialized())
+            return true;
+
         if (oldView.getColumnNames() == null
                 || oldView.getColumnNames().isEmpty()) {
             oldViewColumnNames = null;

--- a/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
@@ -55,10 +55,11 @@ public class PgDumpLoader { //NOPMD
             "^CREATE[\\s]+TABLE[\\s]+.*$",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     /**
-     * Pattern for testing whether it is CREATE VIEW statement.
+     * Pattern for testing whether it is CREATE VIEW or CREATE MATERIALIZED
+     * VIEW statement.
      */
     private static final Pattern PATTERN_CREATE_VIEW = Pattern.compile(
-            "^CREATE[\\s]+(?:OR[\\s]+REPLACE[\\s]+)?VIEW[\\s]+.*$",
+            "^CREATE[\\s]+(?:OR[\\s]+REPLACE[\\s]+)?(?:MATERIALIZED[\\s]+)?VIEW[\\s]+.*$",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     /**
      * Pattern for testing whether it is ALTER TABLE statement.

--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateIndexParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateIndexParser.java
@@ -6,10 +6,8 @@
 package cz.startnet.utils.pgdiff.parsers;
 
 import cz.startnet.utils.pgdiff.Resources;
-import cz.startnet.utils.pgdiff.schema.PgDatabase;
-import cz.startnet.utils.pgdiff.schema.PgIndex;
-import cz.startnet.utils.pgdiff.schema.PgSchema;
-import cz.startnet.utils.pgdiff.schema.PgTable;
+import cz.startnet.utils.pgdiff.schema.*;
+
 import java.text.MessageFormat;
 
 /**
@@ -54,18 +52,24 @@ public class CreateIndexParser {
 
         final String objectName = ParserUtils.getObjectName(tableName);
         final PgTable table = schema.getTable(objectName);
+        final PgView view = schema.getView(objectName);
+        final PgIndex index = new PgIndex(indexName);
 
-        if (table == null) {
+        if (table != null) {
+            table.addIndex(index);
+        }
+        else if (view != null) {
+            view.addIndex(index);
+        }
+        else {
             throw new RuntimeException(MessageFormat.format(
-                    Resources.getString("CannotFindTable"), tableName,
+                    Resources.getString("CannotFindObject"), tableName,
                     statement));
         }
 
-        final PgIndex index = new PgIndex(indexName);
-        table.addIndex(index);
         schema.addIndex(index);
         index.setDefinition(definition.trim());
-        index.setTableName(table.getName());
+        index.setTableName(objectName);
         index.setUnique(unique);
     }
 

--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateViewParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateViewParser.java
@@ -29,8 +29,10 @@ public class CreateViewParser {
     public static void parse(final PgDatabase database,
             final String statement) {
         final Parser parser = new Parser(statement);
+
         parser.expect("CREATE");
         parser.expectOptional("OR", "REPLACE");
+        final boolean materialized = parser.expectOptional("MATERIALIZED");
         parser.expect("VIEW");
 
         final String viewName = parser.parseIdentifier();
@@ -51,6 +53,7 @@ public class CreateViewParser {
         final String query = parser.getRest();
 
         final PgView view = new PgView(ParserUtils.getObjectName(viewName));
+        view.setMaterialized(materialized);
         view.setColumnNames(columnNames);
         view.setQuery(query);
 

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgView.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgView.java
@@ -26,6 +26,10 @@ public class PgView {
      */
     private final String name;
     /**
+     * Is this a MATERIALIZED view?
+     */
+    private boolean materialized;
+    /**
      * SQL query of the view.
      */
     private String query;
@@ -97,7 +101,10 @@ public class PgView {
      */
     public String getCreationSQL() {
         final StringBuilder sbSQL = new StringBuilder(query.length() * 2);
-        sbSQL.append("CREATE VIEW ");
+        sbSQL.append("CREATE ");
+        if (materialized)
+            sbSQL.append("MATERIALIZED ");
+        sbSQL.append("VIEW ");
         sbSQL.append(PgDiffUtils.getQuotedName(name));
 
         if (columnNames != null && !columnNames.isEmpty()) {
@@ -157,7 +164,8 @@ public class PgView {
      * @return created SQL statement
      */
     public String getDropSQL() {
-        return "DROP VIEW " + PgDiffUtils.getQuotedName(getName()) + ";";
+        return "DROP " + (materialized ? "MATERIALIZED " : "") +
+                "VIEW " + PgDiffUtils.getQuotedName(getName()) + ";";
     }
 
     /**
@@ -167,6 +175,24 @@ public class PgView {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Setter for {@link #materialized}.
+     *
+     * @param materialized {@link #materialized}
+     */
+    public void setMaterialized(boolean materialized) {
+        this.materialized = materialized;
+    }
+
+    /**
+     * Getter for {@link #materialized}.
+     *
+     * @return {@link #materialized}
+     */
+    public boolean isMaterialized() {
+        return materialized;
     }
 
     /**
@@ -255,6 +281,15 @@ public class PgView {
      */
     public List<ColumnComment> getColumnComments() {
         return Collections.unmodifiableList(columnComments);
+    }
+
+    /**
+     * Adds {@code index} to the list of indexes.
+     *
+     * @param index index
+     */
+    public void addIndex(final PgIndex index) {
+        /* TODO write code here */
     }
 
     /**


### PR DESCRIPTION
PostgreSQL 9.3 added support for materialized views, but apgdiff doesn't support it yet. Matviews share some traits with views (mostly CREATE MATERIALIZED VIEW) and other traits with tables (indexes & ALTER MAT.VIEW).

This patch adds basic support for matviews; I wanted to get some feedback before I invest more time into this. Copy-pasting relevant code from table/view classes together wouldn't be very nice. My thoughts so far:
* Factor out common code from PgTable and PgView into a new class, maybe PgRelation? (That's what Postgres calls them)
* Merge AlterTableParser and AlterViewParser into a single class -- there is already a fair amount of duplication in these (AlterTableParser has a parseView method!). This also mirrors how the PostgreSQL grammar works -- the syntax for all ALTER relation commands is common and only implementations differ.
* Should I keep materialized views separate from PgView or keep them together? IMO there's no need for another class.

That's quite a bit of work.

Limitations of the current code:
* It seems that the apgdiff parser is too simplistic to handle WITH DATA/WITH NO DATA, but handling them as part of the view query works without problems.
* No COMMENT ON
* No ALTER MATERIALIZED VIEW (though pg_dump generates ALTER TABLEs so basic usage is covered)
* CREATE INDEX commands on matviews are currently ignored
* Probably many more...

PS: Most projects using git keep their active development on the "master" branch and stable code lives in a separate one. I think you should do that too, it makes it easier to get started and I don't have to manually set the source branch when submitting a pull request.
