### PR TITLE
Proposed fix for issue #146: int4range type default value cases error

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/Parser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/Parser.java
@@ -345,9 +345,9 @@ public final class Parser {
         for (; charPos < string.length(); charPos++) {
             final char chr = string.charAt(charPos);
 
-            if (chr == '(') {
+            if ((chr == '(') && !singleQuoteOn) {
                 bracesCount++;
-            } else if (chr == ')') {
+            } else if ((chr == ')') && !singleQuoteOn) {
                 if (bracesCount == 0) {
                     break;
                 } else {


### PR DESCRIPTION
In getExpressionEnd(), when checking for "(" or ")", ensure the current state is not singleQuoteOn. If we are inside a string literal, we must not interpret these characters as special.