### PR TITLE
use using column::type to cast the type of column

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/PgDiffTables.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/PgDiffTables.java
@@ -301,7 +301,7 @@ public class PgDiffTables {
 
             if (!oldColumn.getType().equals(newColumn.getType())) {
                 statements.add("\tALTER COLUMN " + newColumnName + " TYPE "
-                        + newColumn.getType() + " /* "
+                        + newColumn.getType() + " USING " + newColumnName  + "::" + newColumn.getType() + " /* "
                         + MessageFormat.format(
                         Resources.getString("TypeParameterChange"),
                         newTable.getName(), oldColumn.getType(),


### PR DESCRIPTION
If we don't do this, the original type cannot cast to be right type, and the type of column also not  be cast expectantly
