### PR TITLE
detect view query changes even when the view has declared columns that didn't change

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ fordfrog@fordfrog.com.
   unsupported command string is shorter than 20 characters. (Linas Valiukas)
 * Added Spanish translation. (Sebastian Ortiz)
 * Fitted English help to 80 characters in width. (Dave Jarvis)
+* View query changes are now correctly detected even if it has declared
+  columns that didn't change. (Marti Raudsepp)
 
 ### 2012-09-21: Version 2.4
 

--- a/src/main/java/cz/startnet/utils/pgdiff/PgDiffViews.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/PgDiffViews.java
@@ -79,6 +79,9 @@ public class PgDiffViews {
      */
     private static boolean isViewModified(final PgView oldView,
             final PgView newView) {
+        if (!oldView.getQuery().trim().equals(newView.getQuery().trim()))
+            return true;
+
         final String[] oldViewColumnNames;
 
         if (oldView.getColumnNames() == null
@@ -99,11 +102,7 @@ public class PgDiffViews {
                     new String[newView.getColumnNames().size()]);
         }
 
-        if (oldViewColumnNames == null && newViewColumnNames == null) {
-            return !oldView.getQuery().trim().equals(newView.getQuery().trim());
-        } else {
-            return !Arrays.equals(oldViewColumnNames, newViewColumnNames);
-        }
+        return !Arrays.equals(oldViewColumnNames, newViewColumnNames);
     }
 
     /**

--- a/src/test/java/cz/startnet/utils/pgdiff/PgDiffTest.java
+++ b/src/test/java/cz/startnet/utils/pgdiff/PgDiffTest.java
@@ -204,7 +204,9 @@ public class PgDiffTest {
                     // Tests adding new sequence that is owned by table
                     {"add_owned_sequence", false, true, false, false},
                     // Tests adding empty table
-                    {"add_empty_table", false, false, false, false}
+                    {"add_empty_table", false, false, false, false},
+                    // Tests view with column names whose query changes
+                    {"view_colnames", false, false, false, false}
                 });
     }
     /**

--- a/src/test/resources/cz/startnet/utils/pgdiff/view_colnames_diff.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/view_colnames_diff.sql
@@ -1,0 +1,4 @@
+DROP VIEW vx;
+
+CREATE VIEW vx (x) AS
+	select 2;

--- a/src/test/resources/cz/startnet/utils/pgdiff/view_colnames_new.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/view_colnames_new.sql
@@ -1,0 +1,1 @@
+create view vx (x) as select 2;

--- a/src/test/resources/cz/startnet/utils/pgdiff/view_colnames_original.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/view_colnames_original.sql
@@ -1,0 +1,1 @@
+create view vx (x) as select 1;


### PR DESCRIPTION
I discovered this bug when working on refactoring for materialized view support: the view query wasn't being checked at all if old and new view version have declared columns. This leads to failure if the cols didn't change, but the query did.