### PR TITLE
Adding option to ignore CREATE SCHEMA declaration in input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ website at http://apgdiff.startnet.biz/
 * Added switch --ignore-slony-triggers which causes that Slony triggers
   _slony_logtrigger and _slony_denyaccess are completely ignored during parsing
   and diffing.
+* Added switch --ignore-schema-creation which removes the need of CREATE SCHEMA
+  declararions in the input files.
 
 #### Fixes
 * Fixed issue with comments not being added on newly created columns.

--- a/src/main/java/cz/startnet/utils/pgdiff/PgDiff.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/PgDiff.java
@@ -29,11 +29,13 @@ public class PgDiff {
         final PgDatabase oldDatabase = PgDumpLoader.loadDatabaseSchema(
                 arguments.getOldDumpFile(), arguments.getInCharsetName(),
                 arguments.isOutputIgnoredStatements(),
-                arguments.isIgnoreSlonyTriggers());
+                arguments.isIgnoreSlonyTriggers(),
+                arguments.isIgnoreSchemaCreation());
         final PgDatabase newDatabase = PgDumpLoader.loadDatabaseSchema(
                 arguments.getNewDumpFile(), arguments.getInCharsetName(),
                 arguments.isOutputIgnoredStatements(),
-                arguments.isIgnoreSlonyTriggers());
+                arguments.isIgnoreSlonyTriggers(),
+                arguments.isIgnoreSchemaCreation());
 
         diffDatabaseSchemas(writer, arguments, oldDatabase, newDatabase);
     }
@@ -54,11 +56,13 @@ public class PgDiff {
         final PgDatabase oldDatabase = PgDumpLoader.loadDatabaseSchema(
                 oldInputStream, arguments.getInCharsetName(),
                 arguments.isOutputIgnoredStatements(),
-                arguments.isIgnoreSlonyTriggers());
+                arguments.isIgnoreSlonyTriggers(),
+                arguments.isIgnoreSchemaCreation());
         final PgDatabase newDatabase = PgDumpLoader.loadDatabaseSchema(
                 newInputStream, arguments.getInCharsetName(),
                 arguments.isOutputIgnoredStatements(),
-                arguments.isIgnoreSlonyTriggers());
+                arguments.isIgnoreSlonyTriggers(),
+                arguments.isIgnoreSchemaCreation());
 
         diffDatabaseSchemas(writer, arguments, oldDatabase, newDatabase);
     }

--- a/src/main/java/cz/startnet/utils/pgdiff/PgDiffArguments.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/PgDiffArguments.java
@@ -65,6 +65,10 @@ public class PgDiffArguments {
      * Whether Slony triggers should be ignored.
      */
     private boolean ignoreSlonyTriggers;
+    /**
+     * Whether Schema creation should be ignored.
+     */
+    private boolean ignoreSchemaCreation;
 
     /**
      * Setter for {@link #addDefaults}.
@@ -243,6 +247,8 @@ public class PgDiffArguments {
                 setIgnoreSlonyTriggers(true);
             } else if ("--ignore-start-with".equals(args[i])) {
                 setIgnoreStartWith(true);
+            } else if ("--ignore-schema-creation".equals(args[i])) {
+                setIgnoreSchemaCreation(true);
             } else if ("--in-charset-name".equals(args[i])) {
                 setInCharsetName(args[i + 1]);
                 i++;
@@ -387,4 +393,24 @@ public class PgDiffArguments {
     public void setIgnoreSlonyTriggers(final boolean ignoreSlonyTriggers) {
         this.ignoreSlonyTriggers = ignoreSlonyTriggers;
     }
+
+    /**
+     * Getter for {@link #ignoreSchemaCreation}.
+     *
+     * @return {@link #ignoreSchemaCreation}
+     */
+    public boolean isIgnoreSchemaCreation() {
+        return this.ignoreSchemaCreation;
+    }
+    
+    /**
+     * Setter for {@link #ignoreSchemaCreation}.
+     *
+     * @param ignoreSlonyTriggers {@link #ignoreSchemaCreation}
+     */
+    public void setIgnoreSchemaCreation(final boolean ignoreSchemaCreation) {
+        this.ignoreSchemaCreation = ignoreSchemaCreation;
+    }
+    
+    
 }

--- a/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
@@ -145,12 +145,13 @@ public class PgDumpLoader { //NOPMD
      * @param outputIgnoredStatements whether ignored statements should be
      *                                included in the output
      * @param ignoreSlonyTriggers     whether Slony triggers should be ignored
+     * @param ignoreSchemaCreation    whether schema creation should be ignored
      *
      * @return database schema from dump file
      */
     public static PgDatabase loadDatabaseSchema(final InputStream inputStream,
             final String charsetName, final boolean outputIgnoredStatements,
-            final boolean ignoreSlonyTriggers) {
+            final boolean ignoreSlonyTriggers, final boolean ignoreSchemaCreation) {
 
         final PgDatabase database = new PgDatabase();
         BufferedReader reader = null;
@@ -175,7 +176,7 @@ public class PgDumpLoader { //NOPMD
                 matcher.matches();
                 database.setDefaultSchema(matcher.group(1));
             } else if (PATTERN_CREATE_TABLE.matcher(statement).matches()) {
-                CreateTableParser.parse(database, statement);
+                CreateTableParser.parse(database, statement, ignoreSchemaCreation);
             } else if (PATTERN_ALTER_TABLE.matcher(statement).matches()) {
                 AlterTableParser.parse(
                         database, statement, outputIgnoredStatements);
@@ -226,15 +227,16 @@ public class PgDumpLoader { //NOPMD
      * @param outputIgnoredStatements whether ignored statements should be
      *                                included in the output
      * @param ignoreSlonyTriggers     whether Slony triggers should be ignored
+     * @param ignoreSchemaCreation    whether Schema creation should be ignored
      *
      * @return database schema from dump file
      */
     public static PgDatabase loadDatabaseSchema(final String file,
             final String charsetName, final boolean outputIgnoredStatements,
-            final boolean ignoreSlonyTriggers) {
+            final boolean ignoreSlonyTriggers, final boolean ignoreSchemaCreation) {
         try {
             return loadDatabaseSchema(new FileInputStream(file), charsetName,
-                    outputIgnoredStatements, ignoreSlonyTriggers);
+                    outputIgnoredStatements, ignoreSlonyTriggers, ignoreSchemaCreation);
         } catch (final FileNotFoundException ex) {
             throw new FileException(MessageFormat.format(
                     Resources.getString("FileNotFound"), file), ex);

--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateTableParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateTableParser.java
@@ -25,9 +25,10 @@ public class CreateTableParser {
      *
      * @param database  database
      * @param statement CREATE TABLE statement
+     * @param ignoreSchemaCreation whether schema creation should be ignored
      */
     public static void parse(final PgDatabase database,
-            final String statement) {
+            final String statement, final boolean ignoreSchemaCreation) {
         final Parser parser = new Parser(statement);
         parser.expect("CREATE", "TABLE");
 
@@ -38,12 +39,17 @@ public class CreateTableParser {
         final PgTable table = new PgTable(ParserUtils.getObjectName(tableName));
         final String schemaName =
                 ParserUtils.getSchemaName(tableName, database);
-        final PgSchema schema = database.getSchema(schemaName);
+        PgSchema schema = database.getSchema(schemaName);
 
         if (schema == null) {
-            throw new RuntimeException(MessageFormat.format(
+            if (ignoreSchemaCreation) {
+                schema = new PgSchema(schemaName);
+                database.addSchema(schema);
+            } else {
+                throw new RuntimeException(MessageFormat.format(
                     Resources.getString("CannotFindSchema"), schemaName,
                     statement));
+            }
         }
 
         schema.addTable(table);

--- a/src/main/resources/cz/startnet/utils/pgdiff/Resources.properties
+++ b/src/main/resources/cz/startnet/utils/pgdiff/Resources.properties
@@ -23,6 +23,9 @@ ${tab}not, so use this feature only if you know what you are doing\n\
 ${tab}ignores START WITH modifications on SEQUENCEs (default is not to ignore\n\
 ${tab}these changes)\n\
 \n\
+--ignore-schema-creation:\n\
+${tab}Removes the need of CREATE SCHEMA command on the input schemas\n\
+\n\
 --in-charset-name <charset>:\n\
 ${tab}charset that should be used for reading input files (standard charset name\n\
 ${tab}supported by Java, default is UTF-8)\n\

--- a/src/test/java/cz/startnet/utils/pgdiff/loader/PgDumpLoaderTest.java
+++ b/src/test/java/cz/startnet/utils/pgdiff/loader/PgDumpLoaderTest.java
@@ -67,6 +67,6 @@ public class PgDumpLoaderTest {
     public void loadSchema() {
         PgDumpLoader.loadDatabaseSchema(
                 getClass().getResourceAsStream("schema_" + fileIndex + ".sql"),
-                "UTF-8", false, false);
+                "UTF-8", false, false, false);
     }
 }


### PR DESCRIPTION
Adds an option to remove the necessity of a CREATE SCHEMA in the input files. Every schema reference encountered when parsing tables creates said schema in the database.
