### PR TITLE
I have made a few corrections to spanish messages on Resources_es.properties

### DIFF
--- a/src/main/resources/cz/startnet/utils/pgdiff/Resources_es.properties
+++ b/src/main/resources/cz/startnet/utils/pgdiff/Resources_es.properties
@@ -15,9 +15,9 @@ ${tab}por defecto eliminado despu\u00e9s de la conversi\u00f3n.)\n\
 ${tab}agrega START TRANSACTION y COMMIT TRANSACTION al archivo diff generado\n\
 \n\
 --ignore-function-whitespace:\n\
-${tab}ignora multiples espaciones y nuevas l\u00edneas cuando est\u00e1 comprando\n\
+${tab}ignora multiples espacios y nuevas l\u00edneas cuando est\u00e1 comparando\n\
 ${tab}el contenido de funciones - ADVERTENCIA: esto puede causar\n\
-${tab}que funciones parescan ser las mismas en casos que no lo son,\n\
+${tab}que funciones parezcan ser las mismas en casos que no lo son,\n\
 ${tab}s\u00f3lo usa \u00e9sta caracter\u00edstica si sabes lo que estas haciendo\n\
 \n\
 --ignore-start-with:\n\
@@ -38,8 +38,8 @@ ${tab}en estos momentos (no mostrar\u00e1 informaci\u00f3n de ning\u00fana decla
 ${tab}SELECT, INSERT, UPDATE y/o DELETE)\n\
 \n\
 --ignore-slony-triggers:\n\
-${tab}cuando se analizan las declaraciones SQL, ignorea disparados Slony\n\
-${tab}triggers llamados _slony_logtrigger y _slony_denyaccess\n\
+${tab}cuando se analizan las declaraciones SQL, ignora los disparadores Slony\n\
+${tab}llamados _slony_logtrigger y _slony_denyaccess\n\
 \n\
 --list-charsets\n\
 ${tab}lista todos los charsets soportados
@@ -52,7 +52,7 @@ TypeParameterChange=TIPO cambio - tabla: {0} original: {1} nueva: {2}
 UnsupportedEncoding=Encoding no soportado
 CannotReadFile=No se puede leer el archivo
 FileNotFound=Archivo ''{0}'' no encontrado
-CannotFindColumnInTable=No se puede encontra la columna ''{0}'' en la tabla ''{1}''
+CannotFindColumnInTable=No se puede encontrar la columna ''{0}'' en la tabla ''{1}''
 CannotParseStringExpectedWord=No se puede an\u00e1lizar la cadena: {0}\nEsperando {1} en la posici\u00f3n {2} ''{3}''
 CannotParseStringExpectedInteger=No se puede an\u00e1lizar la cadena: {0}\nEsperando entero en la posici\u00f3n {1} ''{2}''
 CannotParseStringExpectedString=No se puede an\u00e1lizar la cadena: {0}\nEsperando cadena en la posici\u00f3n {1}
@@ -63,6 +63,6 @@ CannotFindSchema=No se puede encontrar el esquema ''{0}'' para la declaraci\u00f
 CannotFindView=No se puede encontrar la vista ''{0}'' para la declaraci\u00f3n ''{1}''. Falta la declaraci\u00f3n CREATE VIEW?
 CannotFindObject=No se puede encontrar el objeto ''{0}'' para la declaraci\u00f3n ''{1}''.
 CannotFindTableColumn=No se puede encontrar la columna ''{0}'' en la tabla ''{1}'' para la declaraci\u00f3n ''{2}''.
-CannotFindTable=No se puede encontrar la table ''{0}'' para la declaraci\u00f3n ''{1}''. Falta la declaraci\u00f3n CREATE TABLE?
+CannotFindTable=No se puede encontrar la tabla ''{0}'' para la declaraci\u00f3n ''{1}''. Falta la declaraci\u00f3n CREATE TABLE?
 CannotFindSequence=No se puede encontrar la secuencia ''{0}'' para la declaraci\u00f3n ''{1}''. Falta la declaraci\u00f3n CREATE SEQUENCE?
 EndOfStatementNotFound=No se puede encontrar punto y coma final para la declaraci\u00f3n: {0}


### PR DESCRIPTION
Hi, I have forked your repository to adapt apgdiff so it can output the diff between a pg_dump exported schema and a pgmodeler (http://pgmodeler.com.br/) exported schema. While doing this I have noticed that you have a file for spanish messages but some of this messages are misspelled so I fix them. I hope you like it and thanks for your work on apgdiff ;).

Best regards,
Bernardo.