### PR TITLE
Native for OS line endings in resulting diff.

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/PgDiffSequences.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/PgDiffSequences.java
@@ -120,7 +120,8 @@ public class PgDiffSequences {
 
             if (newIncrement != null
                     && !newIncrement.equals(oldIncrement)) {
-                sbSQL.append("\n\tINCREMENT BY ");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("\tINCREMENT BY ");
                 sbSQL.append(newIncrement);
             }
 
@@ -128,10 +129,12 @@ public class PgDiffSequences {
             final String newMinValue = newSequence.getMinValue();
 
             if (newMinValue == null && oldMinValue != null) {
-                sbSQL.append("\n\tNO MINVALUE");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("\tNO MINVALUE");
             } else if (newMinValue != null
                     && !newMinValue.equals(oldMinValue)) {
-                sbSQL.append("\n\tMINVALUE ");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("\tMINVALUE ");
                 sbSQL.append(newMinValue);
             }
 
@@ -139,10 +142,12 @@ public class PgDiffSequences {
             final String newMaxValue = newSequence.getMaxValue();
 
             if (newMaxValue == null && oldMaxValue != null) {
-                sbSQL.append("\n\tNO MAXVALUE");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("\tNO MAXVALUE");
             } else if (newMaxValue != null
                     && !newMaxValue.equals(oldMaxValue)) {
-                sbSQL.append("\n\tMAXVALUE ");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("\tMAXVALUE ");
                 sbSQL.append(newMaxValue);
             }
 
@@ -151,7 +156,8 @@ public class PgDiffSequences {
                 final String newStart = newSequence.getStartWith();
 
                 if (newStart != null && !newStart.equals(oldStart)) {
-                    sbSQL.append("\n\tRESTART WITH ");
+                    sbSQL.append(System.getProperty("line.separator"));
+                    sbSQL.append("\tRESTART WITH ");
                     sbSQL.append(newStart);
                 }
             }
@@ -160,7 +166,8 @@ public class PgDiffSequences {
             final String newCache = newSequence.getCache();
 
             if (newCache != null && !newCache.equals(oldCache)) {
-                sbSQL.append("\n\tCACHE ");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("\tCACHE ");
                 sbSQL.append(newCache);
             }
 
@@ -168,16 +175,19 @@ public class PgDiffSequences {
             final boolean newCycle = newSequence.isCycle();
 
             if (oldCycle && !newCycle) {
-                sbSQL.append("\n\tNO CYCLE");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("\tNO CYCLE");
             } else if (!oldCycle && newCycle) {
-                sbSQL.append("\n\tCYCLE");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("\tCYCLE");
             }
 
             final String oldOwnedBy = oldSequence.getOwnedBy();
             final String newOwnedBy = newSequence.getOwnedBy();
 
             if (newOwnedBy != null && !newOwnedBy.equals(oldOwnedBy)) {
-                sbSQL.append("\n\tOWNED BY ");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("\tOWNED BY ");
                 sbSQL.append(newOwnedBy);
             }
 

--- a/src/main/java/cz/startnet/utils/pgdiff/PgDiffTables.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/PgDiffTables.java
@@ -442,20 +442,19 @@ public class PgDiffTables {
             final String newDefault = (newColumn.getDefaultValue() == null) ? ""
                     : newColumn.getDefaultValue();
             if (!oldDefault.equals(newDefault)) {
+                writer.println();
+                writer.print("ALTER TABLE ONLY ");
+                writer.println(PgDiffUtils.getQuotedName(newTable.getName()));
+                writer.print("\tALTER COLUMN ");
+                writer.print(PgDiffUtils.getQuotedName(newColumn.getInheritedColumn().getName()));
                 if (newDefault.length() == 0) {
-                    writer.println(String.format(
-                        "\nALTER TABLE ONLY %s\n\tALTER COLUMN %s DROP DEFAULT;",
-                        PgDiffUtils.getQuotedName(newTable.getName()),
-                        PgDiffUtils.getQuotedName(newColumn.getInheritedColumn().getName())
-                    ));
-                } else {
-                    writer.println(String.format(
-                        "\nALTER TABLE ONLY %s\n\tALTER COLUMN %s SET DEFAULT %s;",
-                        PgDiffUtils.getQuotedName(newTable.getName()),
-                        PgDiffUtils.getQuotedName(newColumn.getInheritedColumn().getName()),
-                        newDefault
-                    ));
+                    writer.print(" DROP DEFAULT");
+                } else
+                {
+                    writer.print(" SET DEFAULT ");
+                    writer.print(newDefault);
                 }
+                writer.println(";");
             }
         }
     }

--- a/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
@@ -293,7 +293,7 @@ public class PgDumpLoader { //NOPMD
                 }
 
                 if (sbStatement.length() > 0) {
-                    sbStatement.append('\n');
+                    sbStatement.append(System.getProperty("line.separator"));
                 }
 
                 pos = sbStatement.length();

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgConstraint.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgConstraint.java
@@ -55,14 +55,17 @@ public class PgConstraint {
         final StringBuilder sbSQL = new StringBuilder(100);
         sbSQL.append("ALTER TABLE ");
         sbSQL.append(PgDiffUtils.getQuotedName(getTableName()));
-        sbSQL.append("\n\tADD CONSTRAINT ");
+        sbSQL.append(System.getProperty("line.separator"));
+        sbSQL.append("\tADD CONSTRAINT ");
         sbSQL.append(PgDiffUtils.getQuotedName(getName()));
         sbSQL.append(' ');
         sbSQL.append(getDefinition());
         sbSQL.append(';');
 
         if (comment != null && !comment.isEmpty()) {
-            sbSQL.append("\n\nCOMMENT ON CONSTRAINT ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("COMMENT ON CONSTRAINT ");
             sbSQL.append(PgDiffUtils.getQuotedName(name));
             sbSQL.append(" ON ");
             sbSQL.append(PgDiffUtils.getQuotedName(tableName));
@@ -119,7 +122,8 @@ public class PgConstraint {
         final StringBuilder sbSQL = new StringBuilder(100);
         sbSQL.append("ALTER TABLE ");
         sbSQL.append(PgDiffUtils.getQuotedName(getTableName()));
-        sbSQL.append("\n\tDROP CONSTRAINT ");
+        sbSQL.append(System.getProperty("line.separator"));
+        sbSQL.append("\tDROP CONSTRAINT ");
         sbSQL.append(PgDiffUtils.getQuotedName(getName()));
         sbSQL.append(';');
 

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgFunction.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgFunction.java
@@ -82,7 +82,9 @@ public class PgFunction {
         sbSQL.append(';');
 
         if (comment != null && !comment.isEmpty()) {
-            sbSQL.append("\n\nCOMMENT ON FUNCTION ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("COMMENT ON FUNCTION ");
             sbSQL.append(PgDiffUtils.getQuotedName(name));
             sbSQL.append('(');
 

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgIndex.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgIndex.java
@@ -84,7 +84,9 @@ public class PgIndex {
         sbSQL.append(';');
 
         if (comment != null && !comment.isEmpty()) {
-            sbSQL.append("\n\nCOMMENT ON INDEX ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("COMMENT ON INDEX ");
             sbSQL.append(PgDiffUtils.getQuotedName(name));
             sbSQL.append(" IS ");
             sbSQL.append(comment);

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgRelation.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgRelation.java
@@ -103,7 +103,9 @@ public abstract class PgRelation {
         final StringBuilder sbSQL = new StringBuilder(100);
 
         if (comment != null && !comment.isEmpty()) {
-            sbSQL.append("\n\nCOMMENT ON ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("COMMENT ON ");
             sbSQL.append(getRelationKind());
             sbSQL.append(' ');
             sbSQL.append(PgDiffUtils.getQuotedName(name));
@@ -114,7 +116,9 @@ public abstract class PgRelation {
 
         for (final PgColumn column : columns) {
             if (column.getComment() != null && !column.getComment().isEmpty()) {
-                sbSQL.append("\n\nCOMMENT ON COLUMN ");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("COMMENT ON COLUMN ");
                 sbSQL.append(PgDiffUtils.getQuotedName(name));
                 sbSQL.append('.');
                 sbSQL.append(PgDiffUtils.getQuotedName(column.getName()));

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgSchema.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgSchema.java
@@ -141,7 +141,9 @@ public class PgSchema {
         sbSQL.append(';');
 
         if (comment != null && !comment.isEmpty()) {
-            sbSQL.append("\n\nCOMMENT ON SCHEMA ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("COMMENT ON SCHEMA ");
             sbSQL.append(PgDiffUtils.getQuotedName(name));
             sbSQL.append(" IS ");
             sbSQL.append(comment);

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgSequence.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgSequence.java
@@ -107,16 +107,19 @@ public class PgSequence {
         sbSQL.append(PgDiffUtils.getQuotedName(name));
 
         if (startWith != null) {
-            sbSQL.append("\n\tSTART WITH ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("\tSTART WITH ");
             sbSQL.append(startWith);
         }
 
         if (increment != null) {
-            sbSQL.append("\n\tINCREMENT BY ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("\tINCREMENT BY ");
             sbSQL.append(increment);
         }
 
-        sbSQL.append("\n\t");
+        sbSQL.append(System.getProperty("line.separator"));
+        sbSQL.append("\t");
 
         if (maxValue == null) {
             sbSQL.append("NO MAXVALUE");
@@ -125,7 +128,8 @@ public class PgSequence {
             sbSQL.append(maxValue);
         }
 
-        sbSQL.append("\n\t");
+        sbSQL.append(System.getProperty("line.separator"));
+        sbSQL.append("\t");
 
         if (minValue == null) {
             sbSQL.append("NO MINVALUE");
@@ -135,18 +139,22 @@ public class PgSequence {
         }
 
         if (cache != null) {
-            sbSQL.append("\n\tCACHE ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("\tCACHE ");
             sbSQL.append(cache);
         }
 
         if (cycle) {
-            sbSQL.append("\n\tCYCLE");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("\tCYCLE");
         }
 
         sbSQL.append(';');
 
         if (comment != null && !comment.isEmpty()) {
-            sbSQL.append("\n\nCOMMENT ON SEQUENCE ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("COMMENT ON SEQUENCE ");
             sbSQL.append(PgDiffUtils.getQuotedName(name));
             sbSQL.append(" IS ");
             sbSQL.append(comment);
@@ -168,7 +176,8 @@ public class PgSequence {
         sbSQL.append(PgDiffUtils.getQuotedName(name));
 
         if (ownedBy != null && !ownedBy.isEmpty()) {
-            sbSQL.append("\n\tOWNED BY ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("\tOWNED BY ");
             sbSQL.append(ownedBy);
         }
 

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgTable.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgTable.java
@@ -116,7 +116,8 @@ public class PgTable extends PgRelation {
         }
         sbSQL.append("TABLE ");
         sbSQL.append(PgDiffUtils.getQuotedName(name));
-        sbSQL.append(" (\n");
+        sbSQL.append(" (");
+        sbSQL.append(System.getProperty("line.separator"));
 
         boolean first = true;
 
@@ -127,18 +128,21 @@ public class PgTable extends PgRelation {
                 if (first) {
                     first = false;
                 } else {
-                    sbSQL.append(",\n");
+                    sbSQL.append(",");
+                    sbSQL.append(System.getProperty("line.separator"));
                 }
 
                 sbSQL.append("\t");
                 sbSQL.append(column.getFullDefinition(false));
             }
 
-            sbSQL.append("\n)");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append(")");
         }
 
         if (inherits != null && !inherits.isEmpty()) {
-            sbSQL.append("\nINHERITS (");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("INHERITS (");
 
             first = true;
 
@@ -161,7 +165,7 @@ public class PgTable extends PgRelation {
         }
 
         if (with != null && !with.isEmpty()) {
-            sbSQL.append("\n");
+            sbSQL.append(System.getProperty("line.separator"));
 
             if ("OIDS=false".equalsIgnoreCase(with)) {
                 sbSQL.append("WITHOUT OIDS");
@@ -178,7 +182,8 @@ public class PgTable extends PgRelation {
         }
 
         if (tablespace != null && !tablespace.isEmpty()) {
-            sbSQL.append("\nTABLESPACE ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("TABLESPACE ");
             sbSQL.append(tablespace);
         }
 
@@ -187,9 +192,12 @@ public class PgTable extends PgRelation {
         //Inherited column default override
         for (PgInheritedColumn column : getInheritedColumns()) {
             if(column.getDefaultValue() != null){
-                sbSQL.append("\n\nALTER TABLE ONLY ");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("ALTER TABLE ONLY ");
                 sbSQL.append(PgDiffUtils.getQuotedName(name));
-                sbSQL.append("\n\tALTER COLUMN ");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("\tALTER COLUMN ");
                 sbSQL.append(
                     PgDiffUtils.getQuotedName(column.getInheritedColumn().getName()));
                 sbSQL.append(" SET DEFAULT ");
@@ -199,7 +207,8 @@ public class PgTable extends PgRelation {
         }
 
         for (PgColumn column : getColumnsWithStatistics()) {
-            sbSQL.append("\nALTER TABLE ONLY ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("ALTER TABLE ONLY ");
             sbSQL.append(PgDiffUtils.getQuotedName(name));
             sbSQL.append(" ALTER COLUMN ");
             sbSQL.append(

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgTrigger.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgTrigger.java
@@ -114,7 +114,8 @@ public class PgTrigger {
         final StringBuilder sbSQL = new StringBuilder(100);
         sbSQL.append("CREATE TRIGGER ");
         sbSQL.append(PgDiffUtils.getQuotedName(getName()));
-        sbSQL.append("\n\t");
+        sbSQL.append(System.getProperty("line.separator"));
+        sbSQL.append("\t");
         sbSQL.append(isBefore() ? "BEFORE" : "AFTER");
 
         boolean firstEvent = true;
@@ -169,21 +170,26 @@ public class PgTrigger {
 
         sbSQL.append(" ON ");
         sbSQL.append(PgDiffUtils.getQuotedName(getTableName()));
-        sbSQL.append("\n\tFOR EACH ");
+        sbSQL.append(System.getProperty("line.separator"));
+        sbSQL.append("\tFOR EACH ");
         sbSQL.append(isForEachRow() ? "ROW" : "STATEMENT");
 
         if (when != null && !when.isEmpty()) {
-            sbSQL.append("\n\tWHEN (");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("\tWHEN (");
             sbSQL.append(when);
             sbSQL.append(')');
         }
 
-        sbSQL.append("\n\tEXECUTE PROCEDURE ");
+        sbSQL.append(System.getProperty("line.separator"));
+        sbSQL.append("\tEXECUTE PROCEDURE ");
         sbSQL.append(getFunction());
         sbSQL.append(';');
 
         if (comment != null && !comment.isEmpty()) {
-            sbSQL.append("\n\nCOMMENT ON TRIGGER ");
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append(System.getProperty("line.separator"));
+            sbSQL.append("COMMENT ON TRIGGER ");
             sbSQL.append(PgDiffUtils.getQuotedName(name));
             sbSQL.append(" ON ");
             sbSQL.append(PgDiffUtils.getQuotedName(tableName));

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgView.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgView.java
@@ -116,7 +116,9 @@ public class PgView extends PgRelation {
             sbSQL.append(')');
         }
 
-        sbSQL.append(" AS\n\t");
+        sbSQL.append(" AS");
+        sbSQL.append(System.getProperty("line.separator"));
+        sbSQL.append("\t");
         sbSQL.append(query);
         sbSQL.append(';');
 
@@ -125,7 +127,9 @@ public class PgView extends PgRelation {
             String defaultValue = col.getDefaultValue();
 
             if (defaultValue != null && !defaultValue.isEmpty()) {
-                sbSQL.append("\n\nALTER ");
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append(System.getProperty("line.separator"));
+                sbSQL.append("ALTER ");
                 sbSQL.append(getRelationKind());
                 sbSQL.append(' ');
                 sbSQL.append(PgDiffUtils.getQuotedName(name));


### PR DESCRIPTION
**Problem description**
Resulting diff has different line endings on Windows (\r\n and \n). There are two main reasons why it should be fixed:
- it is ugly;
- unit tests don't pass because of that.

**Solution**
Replace all usages of '\n' with System.getProperty("line.separator").