### PR TITLE
Issue #125 - Allow escaped characters other than quotes inside string

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
@@ -368,10 +368,10 @@ public class PgDumpLoader { //NOPMD
             pos = sbStatement.indexOf("--", pos + 1);
         }
 
+        int startPos = sbStatement.indexOf("/*");
         int endPos = sbStatement.indexOf("*/");
-        if (endPos >= 0) {
-        	int startPos = sbStatement.indexOf("/*");
-        	sbStatement.replace(startPos, endPos + 2, "");
+        if (endPos >= 0 && startPos >= 0) {
+            sbStatement.replace(startPos, endPos + 2, "");
         }
     }
 

--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/AlterRelationParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/AlterRelationParser.java
@@ -101,6 +101,8 @@ public class AlterRelationParser {
             } else if (table != null && parser.expectOptional("DISABLE")) {
                 parseDisable(
                         parser, outputIgnoredStatements, relName, database);
+            } else if (table != null && parser.expectOptional("REPLICA", "IDENTITY")) {
+                parseReplicaIdentity(parser, outputIgnoredStatements, relName, database);
             } else {
                 parser.throwUnsupportedCommand();
             }
@@ -362,6 +364,43 @@ public class AlterRelationParser {
             } else {
                 parser.throwUnsupportedCommand();
             }
+        }
+    }
+
+    /**
+     * Parses REPLICA IDENTITY statements.
+     *
+     * @param parser                  parser
+     * @param outputIgnoredStatements whether ignored statements should be
+     *                                output in the diff
+     * @param tableName               table name as it was specified in the
+     *                                statement
+     * @param database                database information
+     */
+    private static void parseReplicaIdentity(final Parser parser,
+            final boolean outputIgnoredStatements, final String tableName,
+            final PgDatabase database) {
+        if (parser.expectOptional("DEFAULT")) {
+            if (outputIgnoredStatements) {
+                database.addIgnoredStatement("ALTER TABLE " + tableName + " REPLICA IDENTITY DEFAULT;");
+            }
+        } else if (parser.expectOptional("USING", "INDEX")) {
+            if (outputIgnoredStatements) {
+                database.addIgnoredStatement("ALTER TABLE " + tableName
+                        + " REPLICA IDENTITY USING INDEX " + parser.parseIdentifier() + ';');
+            } else {
+                parser.parseIdentifier();
+            }
+        } else if (parser.expectOptional("FULL")) {
+            if (outputIgnoredStatements) {
+                database.addIgnoredStatement("ALTER TABLE " + tableName + " REPLICA IDENTITY FULL;");
+            }
+        } else if (parser.expectOptional("NOTHING")) {
+            if (outputIgnoredStatements) {
+                database.addIgnoredStatement("ALTER TABLE " + tableName + " REPLICA IDENTITY NOTHING;");
+            }
+        } else {
+            parser.throwUnsupportedCommand();
         }
     }
 

--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/Parser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/Parser.java
@@ -349,9 +349,9 @@ public final class Parser {
         for (; charPos < string.length(); charPos++) {
             final char chr = string.charAt(charPos);
 
-            if (chr == '(' || chr == '[') {
+            if ((chr == '(' || chr == '[') && !singleQuoteOn) {
                 bracesCount++;
-            } else if (chr == ')' || chr == ']') {
+            } else if ((chr == ')' || chr == ']') && !singleQuoteOn) {
                 if (bracesCount == 0) {
                     break;
                 } else {

--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/Parser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/Parser.java
@@ -253,8 +253,10 @@ public final class Parser {
             for (; endPos < string.length(); endPos++) {
                 final char chr = string.charAt(endPos);
 
-                if (chr == '\\') {
-                    escape = !escape;
+                if (escape) {
+                    escape = false;
+                } else if (chr == '\\') {
+                     escape = true;
                 } else if (!escape && chr == '\'') {
                     if (endPos + 1 < string.length()
                             && string.charAt(endPos + 1) == '\'') {

--- a/src/test/resources/cz/startnet/utils/pgdiff/loader/schema_17.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/loader/schema_17.sql
@@ -1,0 +1,4 @@
+CREATE TABLE test
+(
+    test TEXT DEFAULT '*/'
+);


### PR DESCRIPTION
Basic test case:

CREATE TABLE test
(
	test	TEXT
);
COMMENT ON COLUMN test.test IS 'Hi.\n';