### PR TITLE
Issue #188 - Main sure that at /**/ comment has a start and end before removing it.

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
@@ -368,10 +368,10 @@ public class PgDumpLoader { //NOPMD
             pos = sbStatement.indexOf("--", pos + 1);
         }
 
+        int startPos = sbStatement.indexOf("/*");
         int endPos = sbStatement.indexOf("*/");
-        if (endPos >= 0) {
-        	int startPos = sbStatement.indexOf("/*");
-        	sbStatement.replace(startPos, endPos + 2, "");
+        if (endPos >= 0 && startPos >= 0) {
+            sbStatement.replace(startPos, endPos + 2, "");
         }
     }
 

--- a/src/test/resources/cz/startnet/utils/pgdiff/loader/schema_17.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/loader/schema_17.sql
@@ -1,0 +1,4 @@
+CREATE TABLE test
+(
+    test TEXT DEFAULT '*/'
+);


### PR DESCRIPTION
Not the ideal solution, but a quick fix for this issue I'm having.
I think ideally it would ignore /* */ comments inside quotes in any case.