### PR TITLE
Fixed error with isQuoted

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -93,9 +93,9 @@
     <target name="get-deps" description="Download all dependencies"
             unless="noget">
         <mkdir dir="${lib}"/>
-        <get src="http://mirrors.ibiblio.org/pub/mirrors/maven2/junit/junit/4.8.1/junit-4.8.1.jar"
+        <get src="http://central.maven.org/maven2/junit/junit/4.8.1/junit-4.8.1.jar"
              dest="${lib}/junit.jar"/>
-	<get src="http://mirrors.ibiblio.org/pub/mirrors/maven2/org/hamcrest/hamcrest-all/1.1/hamcrest-all-1.1.jar"
+	<get src="http://central.maven.org/maven2/org/hamcrest/hamcrest-all/1.1/hamcrest-all-1.1.jar"
 	     dest="${lib}/hamcrest-all.jar"/>
     </target>
 

--- a/src/test/java/cz/startnet/utils/pgdiff/PgDiffTest.java
+++ b/src/test/java/cz/startnet/utils/pgdiff/PgDiffTest.java
@@ -229,6 +229,7 @@ public class PgDiffTest {
                     {"add_table_issue115", false, false, false, false},
                     {"add_column_issue134", false, false, false, false},
                     {"add_column_issue188", false, false, false, false},
+                    {"view_alias_with_quote", false, false, false, false},
                     // Tests view triggers (support for 'INSTEAD OF')
                     {"view_triggers", false, false, false, false},
                     // Tests privileges

--- a/src/test/resources/cz/startnet/utils/pgdiff/view_alias_with_quote_diff.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/view_alias_with_quote_diff.sql
@@ -1,0 +1,4 @@
+DROP VIEW foo;
+
+CREATE VIEW foo AS
+	SELECT bar AS "Foo's bar" FROM tableName;

--- a/src/test/resources/cz/startnet/utils/pgdiff/view_alias_with_quote_new.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/view_alias_with_quote_new.sql
@@ -1,0 +1,1 @@
+CREATE VIEW foo AS SELECT bar AS "Foo's bar" FROM tableName;

--- a/src/test/resources/cz/startnet/utils/pgdiff/view_alias_with_quote_original.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/view_alias_with_quote_original.sql
@@ -1,0 +1,1 @@
+CREATE VIEW foo AS SELECT bar AS "Foo's bar", bar2 AS "Foo's second bar" FROM tableName;


### PR DESCRIPTION
If you have an alias a column in a view and the name contains a singe quote the isQuoted method would continue to consume until another single quote was reached. For example: 
`CREATE VIEW foo AS
   SELECT bar AS "Foo's bar"
   FROM tableName;
`would continue to consume statements below this statement.