### PR TITLE
Support ALTER COLUMN ... SET NOT NULL

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/AlterRelationParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/AlterRelationParser.java
@@ -249,6 +249,29 @@ public class AlterRelationParser {
                 }
 
                 column.setStatistics(parser.parseInteger());
+            } else if (parser.expectOptional("NOT NULL")) {
+                if (rel.containsColumn(columnName)) {
+                    final PgColumn column = rel.getColumn(columnName);
+                    if (column == null) {
+                        throw new RuntimeException(MessageFormat.format(
+                                Resources.getString("CannotFindTableColumn"),
+                                columnName, rel.getName(), parser.getString()));
+                    }
+                    column.setNullValue(false);
+                } else if (rel.containsInheritedColumn(columnName)) {
+                    final PgInheritedColumn inheritedColumn = rel.getInheritedColumn(columnName);
+                    if (inheritedColumn == null) {
+                        throw new RuntimeException(MessageFormat.format(
+                                Resources.getString("CannotFindTableColumn"),
+                                columnName, rel.getName(), parser.getString()));
+                    }
+
+                    inheritedColumn.setNullValue(false);
+                } else {
+                    throw new ParserException(MessageFormat.format(
+                            Resources.getString("CannotFindColumnInTable"),
+                            columnName, rel.getName()));
+                }
             } else if (parser.expectOptional("DEFAULT")) {
                 final String defaultValue = parser.getExpression();
 

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgInheritedColumn.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgInheritedColumn.java
@@ -33,6 +33,11 @@ package cz.startnet.utils.pgdiff.schema;
      * Default value of the column.
      */
     private String defaultValue;
+
+    /**
+     * Determines whether null value is allowed in the column.
+     */
+    private boolean nullValue = true;
     
     /**
      * Setter for {@link #defaultValue}.
@@ -50,5 +55,23 @@ package cz.startnet.utils.pgdiff.schema;
      */
     public String getDefaultValue() {
         return defaultValue;
+    }
+
+    /**
+     * Setter for {@link #nullValue}.
+     *
+     * @param nullValue {@link #nullValue}
+     */
+    public void setNullValue(final boolean nullValue) {
+        this.nullValue = nullValue;
+    }
+
+    /**
+     * Getter for {@link #nullValue}.
+     *
+     * @return {@link #nullValue}
+     */
+    public boolean getNullValue() {
+        return nullValue;
     }
  }


### PR DESCRIPTION
This was manifesting on a table that inherited a column from a parent
then set it to not null in the pg_dump via:

ALTER TABLE ONLY table_name ALTER COLUMN inherited_column_name SET NOT NULL;

This change makes this parse successfully.