### PR TITLE
Remove SourceForge repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,17 +198,6 @@
         </plugins>
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>stat-scm-sourceforge</id>
-            <url>http://stat-scm.sourceforge.net/maven2</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>stat-scm-sourceforge-snapshot</id>
-            <url>http://stat-scm.sourceforge.net/maven2-snapshots</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The sourceforge repo is currently timing out and throwing 404s, but the build seems to work fine without it (pulling everything from Maven Central instead).