### PR TITLE
Parse up to 3 identifier parts

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/Parser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/Parser.java
@@ -138,9 +138,13 @@ public final class Parser {
     public String parseIdentifier() {
         String identifier = parseIdentifierInternal();
 
-        if (string.charAt(position) == '.') {
-            position++;
-            identifier += '.' + parseIdentifierInternal();
+        for (int i = 0; i < 2 ; i++) {
+            if (string.charAt(position) == '.') {
+                position++;
+                identifier += '.' + parseIdentifierInternal();
+            } else {
+                break;
+            }
         }
 
         skipWhitespace();


### PR DESCRIPTION
This is intended to enable parsing the output of newer versions of `pg_dump`, which use fully qualified identifiers instead of setting `search_path` (see #159, #173).

I'm not sure if this change would break backwards compatibility. If it does, an optional command line flag could be added to enable this behaviour.