### PR TITLE
DROP NOT NULL with DEFAULT

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgColumn.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgColumn.java
@@ -261,25 +261,25 @@ public class PgColumn {
     public void parseDefinition(final String definition) {
         String string = definition;
 
-        Matcher matcher = PATTERN_NOT_NULL.matcher(string);
+        Matcher matcher = PATTERN_DEFAULT.matcher(string);
+
+        if (matcher.matches()) {
+            string = matcher.group(1).trim();
+            setDefaultValue(matcher.group(2).trim());
+        }
+
+        matcher = PATTERN_NOT_NULL.matcher(string);
 
         if (matcher.matches()) {
             string = matcher.group(1).trim();
             setNullValue(false);
         } else {
-            matcher = PATTERN_NULL.matcher(string);
+        	  matcher = PATTERN_NULL.matcher(string);
 
             if (matcher.matches()) {
                 string = matcher.group(1).trim();
                 setNullValue(true);
             }
-        }
-
-        matcher = PATTERN_DEFAULT.matcher(string);
-
-        if (matcher.matches()) {
-            string = matcher.group(1).trim();
-            setDefaultValue(matcher.group(2).trim());
         }
 
         setType(string);


### PR DESCRIPTION
Drop both "NOT NULL" and "DEFAULT" on table column.
Switch order of parseDefinition patterns apply, otherwise column which has both "NOT NULL" and "DEFAULT" can't be modified to have none of them.

**oldColumn**: column_name column_type NOT NULL DEFAULT default_value
**newColumn**: column_name column_type
**diff (v2.6.0)**: _ALTER TABLE...
ALTER COLUMN column_name column_type,
ALTER COLUMN DROP DEFAULT;_

**but should be**: _ALTER TABLE...
ALTER COLUMN DROP NOT NULL,
ALTER COLUMN DROP DEFAULT;_