### PR TITLE
Dedupe `CREATE SCHEMA PUBLIC` statements

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateSchemaParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateSchemaParser.java
@@ -26,32 +26,20 @@ public class CreateSchemaParser {
         final Parser parser = new Parser(statement);
         parser.expect("CREATE", "SCHEMA");
 
+        String schemaName = ParserUtils.getObjectName(parser.parseIdentifier());
+        PgSchema schema = database.getSchema(schemaName);
+        if (schema == null) {
+            schema = new PgSchema(schemaName);
+            database.addSchema(schema);
+        }
+
         if (parser.expectOptional("AUTHORIZATION")) {
-            final PgSchema schema = new PgSchema(
-                    ParserUtils.getObjectName(parser.parseIdentifier()));
-            database.addSchema(schema);
             schema.setAuthorization(schema.getName());
+        }
 
-            final String definition = parser.getRest();
-
-            if (definition != null && !definition.isEmpty()) {
-                schema.setDefinition(definition);
-            }
-        } else {
-            final PgSchema schema = new PgSchema(
-                    ParserUtils.getObjectName(parser.parseIdentifier()));
-            database.addSchema(schema);
-
-            if (parser.expectOptional("AUTHORIZATION")) {
-                schema.setAuthorization(
-                        ParserUtils.getObjectName(parser.parseIdentifier()));
-            }
-
-            final String definition = parser.getRest();
-
-            if (definition != null && !definition.isEmpty()) {
-                schema.setDefinition(definition);
-            }
+        final String definition = parser.getRest();
+        if (definition != null && !definition.isEmpty()) {
+            schema.setDefinition(definition);
         }
     }
 

--- a/src/main/java/cz/startnet/utils/pgdiff/schema/PgDatabase.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/schema/PgDatabase.java
@@ -5,6 +5,7 @@
  */
 package cz.startnet.utils.pgdiff.schema;
 
+import cz.startnet.utils.pgdiff.parsers.ParserException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -135,8 +136,15 @@ public class PgDatabase {
      * Adds {@code schema} to the lists of schemas.
      *
      * @param schema schema
+     * @throws ParserException Thrown if schema was already added to the database.
      */
     public void addSchema(final PgSchema schema) {
+        for (PgSchema existingSchema : schemas) {
+            if (existingSchema.getName().equals(schema.getName())) {
+                throw new ParserException(
+                    "Schema '" + schema.getName() + "' already added to database");
+            }
+        }
         schemas.add(schema);
     }
 

--- a/src/test/java/cz/startnet/utils/pgdiff/PgDiffTest.java
+++ b/src/test/java/cz/startnet/utils/pgdiff/PgDiffTest.java
@@ -272,6 +272,7 @@ public class PgDiffTest {
                   , {"alter_view_owner", false, false, false, false}
                   , {"grant_on_table_cols_mixed", false, false, false, false}
                   , {"grant_on_view_cols_mixed", false, false, false, false}
+                  , {"create_schema_no_change_table", false, false, false, false}
                 });
     }
     /**

--- a/src/test/resources/cz/startnet/utils/pgdiff/create_schema_no_change_table_new.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/create_schema_no_change_table_new.sql
@@ -1,0 +1,2 @@
+CREATE SCHEMA public;
+CREATE TABLE public.node (instance_id text);

--- a/src/test/resources/cz/startnet/utils/pgdiff/create_schema_no_change_table_original.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/create_schema_no_change_table_original.sql
@@ -1,0 +1,2 @@
+CREATE SCHEMA public;
+CREATE TABLE public.node (instance_id text);


### PR DESCRIPTION
Previously, the CreateSchemaParser blindly added a schema. Instead,
only add the schema if it's not `public`. For additional safety, throw
an error if a user tries to add a schema that already exists.

Fixes #264 