### PR TITLE
Fix issue where rule parsing was throwing:

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateRuleParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateRuleParser.java
@@ -60,7 +60,7 @@ public class CreateRuleParser {
 
         rule.setQuery(query);
 
-        final String schemaName = ParserUtils.getSchemaName(ruleName, database);
+        final String schemaName = ParserUtils.getSchemaName(relationName, database);
         final PgSchema schema = database.getSchema(schemaName);
 
         if (schema == null) {


### PR DESCRIPTION
Exception in thread "main" java.lang.NullPointerException
	at cz.startnet.utils.pgdiff.parsers.CreateRuleParser.parse(CreateRuleParser.java:74)
	at cz.startnet.utils.pgdiff.loader.PgDumpLoader.loadDatabaseSchema(PgDumpLoader.java:275)
	at cz.startnet.utils.pgdiff.loader.PgDumpLoader.loadDatabaseSchema(PgDumpLoader.java:311)
	at cz.startnet.utils.pgdiff.PgDiff.createDiff(PgDiff.java:35)
	at cz.startnet.utils.pgdiff.Main.main(Main.java:39)

when rule was not in default schema (because of incorrect lookup).