### PR TITLE
Two parser error at CREATE TRIGGER fixed

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateTriggerParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateTriggerParser.java
@@ -107,8 +107,15 @@ public class CreateTriggerParser {
             parser.expect(")");
         }
 
-        parser.expect("EXECUTE", "PROCEDURE");
-        trigger.setFunction(parser.getRest());
+        parser.expect("EXECUTE");
+
+        if (parser.expectOptional("PROCEDURE")) {
+            trigger.setFunction(parser.getRest());
+        } else if (parser.expectOptional("FUNCTION")) {
+            trigger.setFunction(parser.getRest());
+        } else {
+            parser.throwUnsupportedCommand();
+        }
 
         final boolean ignoreSlonyTrigger = ignoreSlonyTriggers
                 && ("_slony_logtrigger".equals(trigger.getName())

--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateTriggerParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateTriggerParser.java
@@ -80,9 +80,12 @@ public class CreateTriggerParser {
         if (parser.expectOptional(referencing)) {            
              trigger.setReferencing("\t"+referencing);             
 
-            while( !parser.getSubString(parser.getPosition()-5, parser.getPosition()-4).equals(System.getProperty("line.separator"))){ 
+            while (true) {
+                String nextword = parser.getSubString(parser.getPosition(), parser.getPosition() + 3);
+                if (!(nextword.equals("OLD") || nextword.equals("NEW"))) {
+                    break;
+                }
                 parseReferencing(parser,trigger);
-               
             } 
         }
 

--- a/src/test/java/cz/startnet/utils/pgdiff/PgDiffTest.java
+++ b/src/test/java/cz/startnet/utils/pgdiff/PgDiffTest.java
@@ -272,6 +272,10 @@ public class PgDiffTest {
                   , {"alter_view_owner", false, false, false, false}
                   , {"grant_on_table_cols_mixed", false, false, false, false}
                   , {"grant_on_view_cols_mixed", false, false, false, false}
+                    // Test create trigger in PostgreSQL v12
+                  , {"add_trigger_function_postgres12", false, false, false, false}
+                    // Test create trigger with referencing tables
+                  , {"add_trigger_with_referencing_tables", false, false, false, false}
                 });
     }
     /**

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_function_postgres12_diff.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_function_postgres12_diff.sql
@@ -1,0 +1,14 @@
+
+CREATE OR REPLACE FUNCTION trigger_test1() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE NOTICE 'trigger_test1 invoked';
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER test1_trigger_update
+	AFTER UPDATE ON test1
+	FOR EACH ROW
+	EXECUTE PROCEDURE public.trigger_test1();

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_function_postgres12_new.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_function_postgres12_new.sql
@@ -1,0 +1,114 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 12.4
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: trigger_test1(); Type: FUNCTION; Schema: public; Owner: krioweb2
+--
+
+CREATE FUNCTION public.trigger_test1() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE NOTICE 'trigger_test1 invoked';
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION public.trigger_test1() OWNER TO krioweb2;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: test1; Type: TABLE; Schema: public; Owner: krioweb2
+--
+
+CREATE TABLE public.test1 (
+    id integer NOT NULL,
+    text name
+);
+
+
+ALTER TABLE public.test1 OWNER TO krioweb2;
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE; Schema: public; Owner: krioweb2
+--
+
+CREATE SEQUENCE public.test1_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.test1_id_seq OWNER TO krioweb2;
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: krioweb2
+--
+
+ALTER SEQUENCE public.test1_id_seq OWNED BY public.test1.id;
+
+
+--
+-- Name: test1 id; Type: DEFAULT; Schema: public; Owner: krioweb2
+--
+
+ALTER TABLE ONLY public.test1 ALTER COLUMN id SET DEFAULT nextval('public.test1_id_seq'::regclass);
+
+
+--
+-- Data for Name: test1; Type: TABLE DATA; Schema: public; Owner: krioweb2
+--
+
+COPY public.test1 (id, text) FROM stdin;
+1	mahh
+\.
+
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE SET; Schema: public; Owner: krioweb2
+--
+
+SELECT pg_catalog.setval('public.test1_id_seq', 1, true);
+
+
+--
+-- Name: test1 test1_pkey; Type: CONSTRAINT; Schema: public; Owner: krioweb2
+--
+
+ALTER TABLE ONLY public.test1
+    ADD CONSTRAINT test1_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: test1 test1_trigger_update; Type: TRIGGER; Schema: public; Owner: krioweb2
+--
+
+CREATE TRIGGER test1_trigger_update AFTER UPDATE ON public.test1 FOR EACH ROW EXECUTE FUNCTION public.trigger_test1();
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_function_postgres12_original.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_function_postgres12_original.sql
@@ -1,0 +1,90 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 12.4
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: test1; Type: TABLE; Schema: public; Owner: krioweb2
+--
+
+CREATE TABLE public.test1 (
+    id integer NOT NULL,
+    text name
+);
+
+
+ALTER TABLE public.test1 OWNER TO krioweb2;
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE; Schema: public; Owner: krioweb2
+--
+
+CREATE SEQUENCE public.test1_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.test1_id_seq OWNER TO krioweb2;
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: krioweb2
+--
+
+ALTER SEQUENCE public.test1_id_seq OWNED BY public.test1.id;
+
+
+--
+-- Name: test1 id; Type: DEFAULT; Schema: public; Owner: krioweb2
+--
+
+ALTER TABLE ONLY public.test1 ALTER COLUMN id SET DEFAULT nextval('public.test1_id_seq'::regclass);
+
+
+--
+-- Data for Name: test1; Type: TABLE DATA; Schema: public; Owner: krioweb2
+--
+
+COPY public.test1 (id, text) FROM stdin;
+\.
+
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE SET; Schema: public; Owner: krioweb2
+--
+
+SELECT pg_catalog.setval('public.test1_id_seq', 1, false);
+
+
+--
+-- Name: test1 test1_pkey; Type: CONSTRAINT; Schema: public; Owner: krioweb2
+--
+
+ALTER TABLE ONLY public.test1
+    ADD CONSTRAINT test1_pkey PRIMARY KEY (id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_with_referencing_tables_diff.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_with_referencing_tables_diff.sql
@@ -1,0 +1,27 @@
+
+CREATE OR REPLACE FUNCTION trigger_test1() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE NOTICE 'trigger_test1 invoked';
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER test1_trigger_ref1
+	AFTER UPDATE ON test1
+	REFERENCING OLD TABLE AS old_table
+	FOR EACH ROW
+	EXECUTE PROCEDURE public.trigger_test1();
+
+CREATE TRIGGER test1_trigger_ref2
+	AFTER UPDATE ON test1
+	REFERENCING NEW TABLE AS new_table
+	FOR EACH ROW
+	EXECUTE PROCEDURE public.trigger_test1();
+
+CREATE TRIGGER test1_trigger_ref3
+	AFTER UPDATE ON test1
+	REFERENCING OLD TABLE AS old_table NEW TABLE AS new_table
+	FOR EACH ROW
+	EXECUTE PROCEDURE public.trigger_test1();

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_with_referencing_tables_new.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_with_referencing_tables_new.sql
@@ -1,0 +1,128 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 12.4
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: trigger_test1(); Type: FUNCTION; Schema: public; Owner: krioweb2
+--
+
+CREATE FUNCTION public.trigger_test1() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE NOTICE 'trigger_test1 invoked';
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION public.trigger_test1() OWNER TO krioweb2;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: test1; Type: TABLE; Schema: public; Owner: krioweb2
+--
+
+CREATE TABLE public.test1 (
+    id integer NOT NULL,
+    text name
+);
+
+
+ALTER TABLE public.test1 OWNER TO krioweb2;
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE; Schema: public; Owner: krioweb2
+--
+
+CREATE SEQUENCE public.test1_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.test1_id_seq OWNER TO krioweb2;
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: krioweb2
+--
+
+ALTER SEQUENCE public.test1_id_seq OWNED BY public.test1.id;
+
+
+--
+-- Name: test1 id; Type: DEFAULT; Schema: public; Owner: krioweb2
+--
+
+ALTER TABLE ONLY public.test1 ALTER COLUMN id SET DEFAULT nextval('public.test1_id_seq'::regclass);
+
+
+--
+-- Data for Name: test1; Type: TABLE DATA; Schema: public; Owner: krioweb2
+--
+
+COPY public.test1 (id, text) FROM stdin;
+1	mahh
+\.
+
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE SET; Schema: public; Owner: krioweb2
+--
+
+SELECT pg_catalog.setval('public.test1_id_seq', 1, true);
+
+
+--
+-- Name: test1 test1_pkey; Type: CONSTRAINT; Schema: public; Owner: krioweb2
+--
+
+ALTER TABLE ONLY public.test1
+    ADD CONSTRAINT test1_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: test1 test1_trigger_ref1; Type: TRIGGER; Schema: public; Owner: krioweb2
+--
+
+CREATE TRIGGER test1_trigger_ref1 AFTER UPDATE ON public.test1 REFERENCING OLD TABLE AS old_table FOR EACH ROW EXECUTE FUNCTION public.trigger_test1();
+
+
+--
+-- Name: test1 test1_trigger_ref2; Type: TRIGGER; Schema: public; Owner: krioweb2
+--
+
+CREATE TRIGGER test1_trigger_ref2 AFTER UPDATE ON public.test1 REFERENCING NEW TABLE AS new_table FOR EACH ROW EXECUTE FUNCTION public.trigger_test1();
+
+
+--
+-- Name: test1 test1_trigger_ref3; Type: TRIGGER; Schema: public; Owner: krioweb2
+--
+
+CREATE TRIGGER test1_trigger_ref3 AFTER UPDATE ON public.test1 REFERENCING OLD TABLE AS old_table NEW TABLE AS new_table FOR EACH ROW EXECUTE FUNCTION public.trigger_test1();
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_with_referencing_tables_original.sql
+++ b/src/test/resources/cz/startnet/utils/pgdiff/add_trigger_with_referencing_tables_original.sql
@@ -1,0 +1,90 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 12.4
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: test1; Type: TABLE; Schema: public; Owner: krioweb2
+--
+
+CREATE TABLE public.test1 (
+    id integer NOT NULL,
+    text name
+);
+
+
+ALTER TABLE public.test1 OWNER TO krioweb2;
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE; Schema: public; Owner: krioweb2
+--
+
+CREATE SEQUENCE public.test1_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.test1_id_seq OWNER TO krioweb2;
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: krioweb2
+--
+
+ALTER SEQUENCE public.test1_id_seq OWNED BY public.test1.id;
+
+
+--
+-- Name: test1 id; Type: DEFAULT; Schema: public; Owner: krioweb2
+--
+
+ALTER TABLE ONLY public.test1 ALTER COLUMN id SET DEFAULT nextval('public.test1_id_seq'::regclass);
+
+
+--
+-- Data for Name: test1; Type: TABLE DATA; Schema: public; Owner: krioweb2
+--
+
+COPY public.test1 (id, text) FROM stdin;
+\.
+
+
+--
+-- Name: test1_id_seq; Type: SEQUENCE SET; Schema: public; Owner: krioweb2
+--
+
+SELECT pg_catalog.setval('public.test1_id_seq', 1, false);
+
+
+--
+-- Name: test1 test1_pkey; Type: CONSTRAINT; Schema: public; Owner: krioweb2
+--
+
+ALTER TABLE ONLY public.test1
+    ADD CONSTRAINT test1_pkey PRIMARY KEY (id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+


### PR DESCRIPTION
After upgrade to PostgreSQL 10, the parser was failed at **TRIGGER REFERENCE**. Later, after upgrade to PostgreSQL 12, the parser was failed at **EXECUTE FUNCTION**. 
We have patched apgdiff for our project to fix these errors. Please merge this patch if you find worthy!