### PR TITLE
Bump project and java version in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <project name="apgdiff" default="jar" basedir=".">
     <property name="name" value="Another PostgreSQL Diff Tool"/>
-    <property name="version" value="2.5"/>
+    <property name="version" value="2.7"/>
     <property name="build" value="build"/>
     <property name="dist" value="dist"/>
     <property name="build.output" value="${build}/classes"/>
@@ -13,8 +13,8 @@
     <property name="src.resources" value="src/main/resources"/>
     <property name="test.src" value="src/test/java"/>
     <property name="test.resources.src" value="src/test/resources"/>
-    <property name="source" value="1.5"/>
-    <property name="target" value="1.5"/>
+    <property name="source" value="1.8"/>
+    <property name="target" value="1.8"/>
     <property name="main.class" value="cz.startnet.utils.pgdiff.Main"/>
 
     <path id="build.classpath">


### PR DESCRIPTION
The Debian package is still using ant to build apgdiff since maven
requires a lot of extra dependencies which we do not want to download at
build time.