### PR TITLE
Fix build.xml: central.maven.org is no longer a valid domain

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -93,9 +93,9 @@
     <target name="get-deps" description="Download all dependencies"
             unless="noget">
         <mkdir dir="${lib}"/>
-        <get src="http://central.maven.org/maven2/junit/junit/4.8.1/junit-4.8.1.jar"
+        <get src="https://repo.maven.apache.org/maven2/junit/junit/4.8.1/junit-4.8.1.jar"
              dest="${lib}/junit.jar"/>
-	<get src="http://central.maven.org/maven2/org/hamcrest/hamcrest-all/1.1/hamcrest-all-1.1.jar"
+	<get src="https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-all/1.1/hamcrest-all-1.1.jar"
 	     dest="${lib}/hamcrest-all.jar"/>
     </target>
 


### PR DESCRIPTION
Replace with https://repo.maven.apache.org

Tested with `ant` 1.10.12 on Ubuntu 22.04 with openjdk 11.0.20.1.