### PR TITLE
updated maven dependencies link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ fordfrog@fordfrog.com.
 
 This repo is mainly unmaintained. But if you found a bug and create a pull request chances are good that it will be merged.
 
+## Build From Source
+To build from source on Ubuntu, use ant
+```
+sudo apt install ant
+cd <repo_dir>
+ant
+```
+This will compile a apgdiff-\<version>.jar file in dist/ folder.
+
+### Usage
+```
+java -jar <path-to-jar-file> old-schema.sql new-schema.sql
+```
+
+
+
 ## Changelog
 
 ### Version 2.7.0

--- a/build.xml
+++ b/build.xml
@@ -93,9 +93,9 @@
     <target name="get-deps" description="Download all dependencies"
             unless="noget">
         <mkdir dir="${lib}"/>
-        <get src="http://central.maven.org/maven2/junit/junit/4.8.1/junit-4.8.1.jar"
+        <get src="https://repo1.maven.org/maven2/junit/junit/4.8.1/junit-4.8.1.jar"
              dest="${lib}/junit.jar"/>
-	<get src="http://central.maven.org/maven2/org/hamcrest/hamcrest-all/1.1/hamcrest-all-1.1.jar"
+	<get src="https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.1/hamcrest-all-1.1.jar"
 	     dest="${lib}/hamcrest-all.jar"/>
     </target>
 


### PR DESCRIPTION
The maven dependencies links in the build.xml seem to have been obsolete. This commit updates them.

(I am using ant on Ubuntu 20.04 to build from source.)